### PR TITLE
Add support for cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.0.4
+
+- Added CI badge to `README.md`
+- Added cardinality support

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # grammar-builder
 
+![CI](https://github.com/gabriel-peracio/grammar-builder/actions/workflows/ci.yml/badge.svg)
+
 This is a simple helper library to facilitate building [GBNF grammars](https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md) manually (as opposed to automatically generating them from something like a `JSONSchema` file)
 
 ## Why
@@ -49,7 +51,28 @@ const grammarString = myGrammar.build();
   // other-rule ::= "choice: " my-rule
   ```
 - **range**: Output a range of characters
+
   ```typescript
   r.range("[A-Z]+");
   // [A-Z]+
+  ```
+
+- **oneOrMore**: The passed rule must occur one or more times
+
+  ```typescript
+  r.oneOrMore(r.oneOf("a", "b"));
+  // ("a" | "b")+
+  ```
+
+- **zeroOrMore**: The passed rule can be absent or occur multiple times
+
+  ```typescript
+  r.zeroOrMore(r.oneOf("a", "b"));
+  // ("a" | "b")*
+  ```
+
+- **optional**: The passed rule can be absent or occur once
+  ```typescript
+  r.optional(r.oneOf("a", "b"));
+  // ("a" | "b")?
   ```

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 - [x] Add `root` rule
 - [ ] Add support for imports (e.g. define a "iso8601" reference, and then use it in a "date" field in another rule)
-- [ ] Add cardinality support (`oneOrMore`, `zeroOrMore`, `optional`)
+- [x] Add cardinality support (`oneOrMore`, `zeroOrMore`, `optional`)
 - [ ] Add sugar:
   - [ ] `list` allows "listItem, listItem, listItem" or "- listItem\n- listItem\n- listItem", etc.
         unrolls to `"- " listItem ('\n- ' listItem)*`
@@ -14,9 +14,9 @@
 - [x] Add JSDoc explanations for each rule and method
 - [x] Ensure coverage is up to snuff
 - [ ] Add husky to lint and prettify on commit
-- [ ] Add CI
-- [ ] Package and publish on npm
-- [ ] Add examples
+- [x] Add CI
+- [x] Package and publish on npm
+- [ ] Add more examples
 
 ## Research
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "out/index.js",
   "main": "out/index.js",
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A simple grammar builder compatible with GBNF (llama.cpp)",
   "keywords": [
     "grammar",

--- a/src/grammar.test.ts
+++ b/src/grammar.test.ts
@@ -161,6 +161,34 @@ describe("grammarBuilder", () => {
     });
   });
 
+  describe("cardinality", () => {
+    describe.each([
+      ["zeroOrMore", "*"],
+      ["oneOrMore", "+"],
+      ["optional", "?"],
+    ])("%s", (cardinalityName, cardinalityChar) => {
+      it(`should augment a oneOf rule with the "${cardinalityName}" cardinality`, () => {
+        const grammar = new Grammar().root((r) => r[cardinalityName](r.oneOf("a", "b"))).build();
+        expect(grammar).toEqual(`root ::= ("a" | "b")${cardinalityChar}`);
+      });
+      it(`should augment a sequence rule with the "${cardinalityName}" cardinality`, () => {
+        const grammar = new Grammar().root((r) => r[cardinalityName](r.sequence("a", "b"))).build();
+        expect(grammar).toEqual(`root ::= ("a" "b")${cardinalityChar}`);
+      });
+      it(`should augment a range rule with the "${cardinalityName}" cardinality`, () => {
+        const grammar = new Grammar().root((r) => r[cardinalityName](r.range("[0-9]"))).build();
+        expect(grammar).toEqual(`root ::= [0-9]${cardinalityChar}`);
+      });
+      it(`should augment a ref rule with the "${cardinalityName}" cardinality`, () => {
+        const grammar = new Grammar()
+          .define("testRef", (r) => r.sequence("a"))
+          .root((r) => r[cardinalityName](r.ref("testRef")))
+          .build();
+        expect(grammar).toEqual(`test-ref ::= "a"\nroot ::= test-ref${cardinalityChar}`);
+      });
+    });
+  });
+
   describe("root", () => {
     it("should allow building after defining a root rule", () => {
       const grammar = new Grammar().root((r) => r.sequence("a", "b")).build();


### PR DESCRIPTION
Adds warnings to some common gotchas (warnings are muted in production)
Adds support for cardinality
- **oneOrMore**: The passed rule must occur one or more times

  ```typescript
  r.oneOrMore(r.oneOf("a", "b"));
  // ("a" | "b")+
  ```

- **zeroOrMore**: The passed rule can be absent or occur multiple times

  ```typescript
  r.zeroOrMore(r.oneOf("a", "b"));
  // ("a" | "b")*
  ```

- **optional**: The passed rule can be absent or occur once
  ```typescript
  r.optional(r.oneOf("a", "b"));
  // ("a" | "b")?
  ```